### PR TITLE
Add Taskade MCP Server

### DIFF
--- a/catalog/taskade/mcp/mcp/server.yaml
+++ b/catalog/taskade/mcp/mcp/server.yaml
@@ -1,0 +1,16 @@
+identifier: taskade/mcp/mcp
+repo:
+  provider: github.com
+  url: https://github.com/taskade/mcp
+  name: mcp
+  owner: taskade
+server:
+  subdirectory: /
+  name: Taskade MCP Server
+  description: Official Taskade MCP server with 62+ tools for managing workspaces,
+    projects, tasks, AI agents, templates, and media. Works with Claude, Cursor,
+    Windsurf, VS Code, and all MCP clients.
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: true


### PR DESCRIPTION
## Add Taskade MCP Server

Adds [Taskade MCP Server](https://github.com/taskade/mcp) to the Metorial MCP Index.

**Taskade MCP Server** (`@taskade/mcp-server`) is the official MCP server for [Taskade](https://www.taskade.com/) with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media. It works with Claude, Cursor, Windsurf, VS Code, and all MCP clients.

- GitHub: https://github.com/taskade/mcp
- npm: `@taskade/mcp-server`
- License: MIT
- Language: TypeScript