### PR TITLE
Add mycrab-mcp — instant Cloudflare tunnels for AI agents

### DIFF
--- a/catalog/isgudtek/mycrab-mcp/mycrab-mcp/server.yaml
+++ b/catalog/isgudtek/mycrab-mcp/mycrab-mcp/server.yaml
@@ -1,0 +1,14 @@
+identifier: isgudtek/mycrab-mcp/mycrab-mcp
+repo:
+  provider: github.com
+  url: https://github.com/isgudtek/mycrab-mcp
+  name: mycrab-mcp
+  owner: isgudtek
+server:
+  subdirectory: /
+  name: mycrab-mcp
+  description: Instant public HTTPS Cloudflare tunnels for AI agents. Free ephemeral URLs in under 60 seconds, or permanent custom subdomains via Solana micropayment (x402 autonomous flow). Install with uvx mycrab-mcp.
+  flags:
+    isOfficial: false
+    isCommunity: true
+    isHostable: true


### PR DESCRIPTION
**PyPI:** https://pypi.org/project/mycrab-mcp/
**GitHub:** https://github.com/isgudtek/mycrab-mcp

MCP server for mycrab.space — instant public HTTPS URLs via Cloudflare Tunnels for AI agents. Free ephemeral URLs in 60s or permanent custom subdomains via Solana micropayment.

Added catalog entry at `catalog/isgudtek/mycrab-mcp/mycrab-mcp/server.yaml`.