### PR TITLE
Add Clarvia MCP Server — AEO scoring and tool discovery

### DIFF
--- a/catalog/clarvia-project/clarvia-mcp-server/clarvia-mcp-server/categories.yaml
+++ b/catalog/clarvia-project/clarvia-mcp-server/clarvia-mcp-server/categories.yaml
@@ -1,0 +1,3 @@
+- Developer Tools
+- APIs and HTTP Requests
+- AI Tools

--- a/catalog/clarvia-project/clarvia-mcp-server/clarvia-mcp-server/listing.yaml
+++ b/catalog/clarvia-project/clarvia-mcp-server/clarvia-mcp-server/listing.yaml
@@ -1,0 +1,27 @@
+identifier: clarvia-project/clarvia-mcp-server/clarvia-mcp-server
+repo:
+  provider: github.com
+  url: https://github.com/clarvia-project/scanner
+  name: scanner
+  owner: clarvia-project
+  subdirectory: mcp-server
+server:
+  subdirectory: mcp-server
+  name: Clarvia MCP Server
+  description: Search, compare, and score 15,400+ AI agent tools (MCP servers, APIs, CLIs, Skills) with AEO quality scores.
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: false
+description: Clarvia is the directory for AI agent tools, scoring 15,400+ MCP
+  servers, APIs, CLIs, and Skills for agent readiness. The MCP server provides
+  24 tools for searching tools, comparing quality, checking vulnerabilities,
+  getting AEO scores, discovering trending tools, and monitoring demand signals.
+  Backed by real npm download counts, GitHub stars, and CVE data from OSV.dev.
+skills:
+  - Search 15,400+ MCP servers, APIs, CLIs, and Skills
+  - Compare tools by AEO quality score
+  - Check security vulnerabilities via OSV.dev CVE data
+  - Discover trending and popular tools
+  - Analyze demand signals and search trends
+  - Get structured tool metadata and capabilities

--- a/catalog/clarvia-project/clarvia-mcp-server/clarvia-mcp-server/server.yaml
+++ b/catalog/clarvia-project/clarvia-mcp-server/clarvia-mcp-server/server.yaml
@@ -1,0 +1,6 @@
+name: Clarvia MCP Server
+description: Search, compare, and score 15,400+ AI agent tools with AEO quality scores
+version: 1.1.0
+license: MIT
+homepage: https://clarvia.art
+documentation: https://clarvia.art/docs


### PR DESCRIPTION
## What is Clarvia?

[Clarvia](https://clarvia.art) is an AI agent tool directory that scores and indexes 15,400+ tools (MCP servers, APIs, CLIs, Skills) for agent readiness using AEO (Agent Experience Optimization) scoring.

## What this MCP server does

The Clarvia MCP server provides **24 tools** for:
- Searching 15,400+ MCP servers, APIs, CLIs, and Skills
- Comparing tools by AEO quality score
- Checking security vulnerabilities via OSV.dev CVE data
- Discovering trending and popular tools
- Analyzing demand signals and search trends
- Getting structured tool metadata (npm downloads, GitHub stars, pricing)

## Install

```bash
npx clarvia-mcp-server
```

Or via Claude Code:
```bash
claude mcp add clarvia -- npx clarvia-mcp-server
```

## Links

- Homepage: https://clarvia.art
- npm: https://npmjs.com/package/clarvia-mcp-server
- Docs: https://clarvia.art/docs
- GitHub: https://github.com/clarvia-project/scanner/tree/main/mcp-server