### PR TITLE
Add prompt-to-asset and unslop MCP servers

### DIFF
--- a/catalog/MohamedAbdallah-14/prompt-to-asset/prompt-to-asset/server.yaml
+++ b/catalog/MohamedAbdallah-14/prompt-to-asset/prompt-to-asset/server.yaml
@@ -1,0 +1,18 @@
+identifier: MohamedAbdallah-14/prompt-to-asset/prompt-to-asset
+repo:
+  provider: github.com
+  url: https://github.com/MohamedAbdallah-14/prompt-to-asset
+  name: prompt-to-asset
+  owner: MohamedAbdallah-14
+server:
+  subdirectory: /
+  name: Prompt to Asset
+  description: MCP server that generates production-ready visual assets (app icons,
+    favicons, OG images, logos, wordmarks) by routing requests across 30+ image
+    generation models. Three execution modes - inline SVG, external prompt, or full
+    API generation. Zero API key required for first run via Pollinations and Stable
+    Horde free tiers.
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: true

--- a/catalog/MohamedAbdallah-14/unslop/unslop/server.yaml
+++ b/catalog/MohamedAbdallah-14/unslop/unslop/server.yaml
@@ -1,0 +1,17 @@
+identifier: MohamedAbdallah-14/unslop/unslop
+repo:
+  provider: github.com
+  url: https://github.com/MohamedAbdallah-14/unslop
+  name: unslop
+  owner: MohamedAbdallah-14
+server:
+  subdirectory: /
+  name: Unslop
+  description: CLI and MCP server that removes AI writing patterns from text -
+    tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused
+    vocabulary. Works with Claude Code, Codex, Gemini CLI, and Cursor. Five
+    intensity levels and a lint-only audit mode.
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: false


### PR DESCRIPTION
## Add prompt-to-asset and unslop MCP servers

Two new server manifests for the catalog.

---

### prompt-to-asset

**Repo:** https://github.com/MohamedAbdallah-14/prompt-to-asset

An MCP server that generates production-ready visual assets. App icons, favicons, OG images, logos, and wordmarks — by routing requests across 30+ image generation models. Three execution modes: inline SVG generation, external prompt routing, or full API generation. No API key required for a first run; Pollinations and Stable Horde free tiers cover it out of the box.

---

### unslop

**Repo:** https://github.com/MohamedAbdallah-14/unslop

An MCP server (also available as a standalone CLI) that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Works with Claude Code, Codex, Gemini CLI, and Cursor. Five intensity levels and a lint-only audit mode for checking without modifying.

---

Both manifests follow the catalog structure, with `isOfficial: true` since these are the author's own repos.
