### PR TITLE
Add Bortlesboat Bitcoin MCP listing

### DIFF
--- a/catalog/bortlesboat/bitcoin-mcp/bitcoin-mcp/server.yaml
+++ b/catalog/bortlesboat/bitcoin-mcp/bitcoin-mcp/server.yaml
@@ -1,0 +1,14 @@
+identifier: bortlesboat/bitcoin-mcp/bitcoin-mcp
+repo:
+  provider: github.com
+  url: https://github.com/Bortlesboat/bitcoin-mcp
+  name: bitcoin-mcp
+  owner: Bortlesboat
+server:
+  subdirectory: /
+  name: Bortlesboat Bitcoin MCP
+  description: Bitcoin MCP server with 49 tools for fee intelligence, mempool analysis, blocks, transactions, mining, price, supply, and AI agent Bitcoin workflows.
+  flags:
+    isOfficial: false
+    isCommunity: true
+    isHostable: true


### PR DESCRIPTION
## Summary

Adds the Bortlesboat `bitcoin-mcp` server manifest to the Metorial MCP Index.

This is a separate Bitcoin MCP implementation from the existing `AbdelStark/bitcoin-mcp` entry. It is a Python MCP server with 49 tools for Bitcoin fee intelligence, mempool analysis, blocks, transactions, mining, price, supply, and agent workflows.

## Validation

- Checked the manifest includes the expected `identifier`, `repo`, `server`, and `flags` sections
- `git diff --check`

I could not run the repo's Bun-based tooling because `bun` is not installed in this environment.