### PR TITLE
Add Packrift MCP server

### DIFF
--- a/catalog/packrift/packrift-mcp/packrift-mcp/categories.yaml
+++ b/catalog/packrift/packrift-mcp/packrift-mcp/categories.yaml
@@ -1,0 +1,3 @@
+- E-commerce and Retail
+- APIs and HTTP Requests
+- Business Tools

--- a/catalog/packrift/packrift-mcp/packrift-mcp/listing.yaml
+++ b/catalog/packrift/packrift-mcp/packrift-mcp/listing.yaml
@@ -1,0 +1,10 @@
+description: Provides a structured MCP interface for Packrift packaging supplies,
+  including product search, live pricing and inventory checks, package
+  recommendations, shipping estimates, and cart URL creation for ecommerce
+  fulfillment workflows.
+skills:
+  - Search Packrift packaging products by keyword
+  - Retrieve product details, dimensions, variants, and weights
+  - Check live pricing and inventory for selected variants
+  - Recommend packaging for item dimensions, weight, and use case
+  - Estimate shipping rates and create Packrift cart URLs

--- a/catalog/packrift/packrift-mcp/packrift-mcp/server.yaml
+++ b/catalog/packrift/packrift-mcp/packrift-mcp/server.yaml
@@ -1,0 +1,16 @@
+identifier: packrift/packrift-mcp/packrift-mcp
+repo:
+  provider: github.com
+  url: https://github.com/Packrift/packrift-mcp
+  name: packrift-mcp
+  owner: Packrift
+server:
+  subdirectory: /
+  name: Packrift MCP Server
+  description: Search Packrift packaging supplies, retrieve live product pricing
+    and inventory context, recommend package options, estimate shipping, and
+    create Packrift cart URLs for ecommerce fulfillment workflows.
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: true

--- a/catalog/packrift/packrift-mcp/packrift-mcp/tools.yaml
+++ b/catalog/packrift/packrift-mcp/packrift-mcp/tools.yaml
@@ -1,0 +1,110 @@
+tools:
+  - name: search_products
+    description: Search Packrift packaging products by keyword.
+    inputSchema:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: Product search query such as poly mailer, corrugated box, or label.
+        limit:
+          type: number
+          description: Optional maximum number of products to return.
+      additionalProperties: false
+  - name: get_product
+    description: Retrieve full product detail, variants, dimensions, and weight.
+    inputSchema:
+      type: object
+      required:
+        - handle
+      properties:
+        handle:
+          type: string
+          description: Packrift product handle.
+      additionalProperties: false
+  - name: get_pricing
+    description: Retrieve live unit pricing and line totals for variant IDs.
+    inputSchema:
+      type: object
+      required:
+        - variant_ids
+      properties:
+        variant_ids:
+          type: array
+          items:
+            type: string
+          description: Shopify variant IDs to price.
+        quantity:
+          type: number
+          description: Optional quantity for line-total pricing.
+      additionalProperties: false
+  - name: check_inventory
+    description: Check live inventory counts for variant IDs.
+    inputSchema:
+      type: object
+      required:
+        - variant_ids
+      properties:
+        variant_ids:
+          type: array
+          items:
+            type: string
+          description: Shopify variant IDs to check.
+      additionalProperties: false
+  - name: recommend_packaging
+    description: Recommend Packrift packaging options for item dimensions, weight, and use case.
+    inputSchema:
+      type: object
+      required:
+        - dims
+        - weight
+        - use_case
+      properties:
+        dims:
+          type: object
+          description: Item dimensions used for fit recommendations.
+        weight:
+          type: number
+          description: Item weight.
+        use_case:
+          type: string
+          description: Fulfillment use case such as apparel, ecommerce, cushioning, or labels.
+      additionalProperties: false
+  - name: get_shipping_estimate
+    description: Estimate shipping rates for a destination and cart items.
+    inputSchema:
+      type: object
+      required:
+        - zip
+        - country
+        - items
+      properties:
+        zip:
+          type: string
+          description: Destination postal or ZIP code.
+        country:
+          type: string
+          description: Destination country code or country name.
+        items:
+          type: array
+          description: Cart items to rate.
+      additionalProperties: false
+  - name: create_cart_url
+    description: Create a Packrift cart URL for selected items.
+    inputSchema:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          description: Cart line items.
+        discount_code:
+          type: string
+          description: Optional discount code.
+        ref:
+          type: string
+          description: Optional referral/source parameter.
+      additionalProperties: false


### PR DESCRIPTION
## Summary
- Add Packrift MCP Server to the Metorial MCP Index catalog
- Include factual catalog metadata, categories, listing summary, and public tool definitions

## Source links
- Repository: https://github.com/Packrift/packrift-mcp
- Packrift agents/docs page: https://packrift.com/pages/agents
- Hosted MCP endpoint: https://mcp.packrift.com/mcp

## Validation
- Added YAML files parse successfully with Ruby YAML.load_file
- Source URLs return HTTP 200