### PR TITLE
Add YIELD INTELLIGENCE — hosted MCP server for passive income analysis

### DIFF
--- a/catalog/thebrierfox/intuitek-ace/intuitek-ace/categories.yaml
+++ b/catalog/thebrierfox/intuitek-ace/intuitek-ace/categories.yaml
@@ -1,0 +1,3 @@
+- Finance
+- Investment
+- Data Analytics

--- a/catalog/thebrierfox/intuitek-ace/intuitek-ace/listing.yaml
+++ b/catalog/thebrierfox/intuitek-ace/intuitek-ace/listing.yaml
@@ -1,0 +1,9 @@
+description: YIELD INTELLIGENCE is a hosted MCP server for passive income
+  analysis. Fetches live U.S. Treasury rates, dividend ETF yields, REIT data,
+  and preferred stock yields to help users build income-optimized portfolios.
+skills:
+  - Analyze U.S. Treasury bond yields
+  - Screen dividend ETFs by yield
+  - Analyze REIT distribution yields
+  - Track preferred stock yields
+  - Optimize portfolio for monthly income target

--- a/catalog/thebrierfox/intuitek-ace/intuitek-ace/server.yaml
+++ b/catalog/thebrierfox/intuitek-ace/intuitek-ace/server.yaml
@@ -1,0 +1,17 @@
+identifier: thebrierfox/intuitek-ace/intuitek-ace
+repo:
+  provider: github.com
+  url: https://github.com/thebrierfox/intuitek-ace
+  name: intuitek-ace
+  owner: thebrierfox
+server:
+  subdirectory: /
+  name: YIELD INTELLIGENCE
+  description: Hosted remote MCP server for passive income analysis — live U.S.
+    Treasury rates, dividend ETFs, REITs, and preferred stocks. Optimizes
+    portfolio allocations to meet a monthly income target. No API key required.
+    Remote endpoint: https://api.intuitek.ai/yield/mcp
+  flags:
+    isOfficial: false
+    isCommunity: true
+    isHostable: false


### PR DESCRIPTION
## Summary

Adds **YIELD INTELLIGENCE** to the Metorial MCP Index.

**YIELD INTELLIGENCE** (`thebrierfox/intuitek-ace`) is a hosted remote MCP server for passive income and yield analysis:

- Live U.S. Treasury bond rates (T-bills, notes, 30-year bonds)
- Dividend ETF screener (VYM, SCHD, JEPI, and similar)
- REIT distribution yield analysis
- Preferred stock yield tracking
- Portfolio optimizer — builds income-weighted allocations targeting a monthly income goal

**No API key required.** Remote MCP endpoint: `https://api.intuitek.ai/yield/mcp`

Categories: Finance, Investment, Data Analytics