### PR TITLE
Add TWZRD Agent Intel MCP server

### DIFF
--- a/catalog/twzrd-sol/wzrd-intel-live/twzrd-agent-intel/server.yaml
+++ b/catalog/twzrd-sol/wzrd-intel-live/twzrd-agent-intel/server.yaml
@@ -1,0 +1,16 @@
+identifier: twzrd-sol/wzrd-intel-live/twzrd-agent-intel
+repo:
+  provider: github.com
+  url: https://github.com/twzrd-sol/wzrd-intel-live
+  name: wzrd-intel-live
+  owner: twzrd-sol
+server:
+  subdirectory: /
+  name: TWZRD Agent Intel
+  description: On-chain trust scoring MCP server for AI agent wallets on Solana. Verify
+    agent identity and reputation before x402 micropayments. Provides score_agent,
+    preflight_check (free) and get_trust_receipt (paid, x402) tools.
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: true


### PR DESCRIPTION
## Summary

Adds TWZRD Agent Intel to the MCP server catalog.

**Server**: [TWZRD Agent Intel](https://intel.twzrd.xyz)  
**MCP Endpoint**: `https://intel.twzrd.xyz/mcp` (streamable-http)

TWZRD Agent Intel provides on-chain trust scoring for AI agent wallets on Solana. Tools:
- `score_agent(wallet)` — Trust score + on-chain reputation (free)
- `preflight_check(wallet)` — Validates wallet before payment acceptance (free)
- `get_trust_receipt(wallet)` — Cryptographic on-chain trust receipt (paid, x402 micropayment)

**MCP Configuration:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```