### PR TITLE
Add BuyWhere MCP server - real-time product search & price comparison (SEA)

### DIFF
--- a/catalog/BuyWhere/buywhere-mcp/buywhere-mcp/categories.yaml
+++ b/catalog/BuyWhere/buywhere-mcp/buywhere-mcp/categories.yaml
@@ -1,0 +1,4 @@
+- E-Commerce
+- Product Search
+- Shopping
+- Price Comparison

--- a/catalog/BuyWhere/buywhere-mcp/buywhere-mcp/listing.yaml
+++ b/catalog/BuyWhere/buywhere-mcp/buywhere-mcp/listing.yaml
@@ -1,0 +1,7 @@
+description: BuyWhere is a real-time product search and price comparison MCP server covering 260,000+ products across thousands of merchants in Southeast Asia. It gives AI agents instant access to live product data, prices, and availability across Lazada, Shopee, and major retailers.
+skills:
+  - Search products by keyword across multiple merchants
+  - Compare prices across retailers in real time
+  - Get product details, specs, and availability
+  - Find best deals and lowest prices
+  - Access Southeast Asia e-commerce data (Singapore, Malaysia, Philippines, Thailand, Indonesia)

--- a/catalog/BuyWhere/buywhere-mcp/buywhere-mcp/server.yaml
+++ b/catalog/BuyWhere/buywhere-mcp/buywhere-mcp/server.yaml
@@ -1,0 +1,14 @@
+identifier: BuyWhere/buywhere-mcp/buywhere-mcp
+repo:
+  provider: github.com
+  url: https://github.com/BuyWhere/buywhere-mcp
+  name: buywhere-mcp
+  owner: BuyWhere
+server:
+  subdirectory: /
+  name: BuyWhere
+  description: Real-time product search and price comparison across 260K+ products in Southeast Asia.
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: true


### PR DESCRIPTION
## BuyWhere MCP Server

Adds BuyWhere to the catalog — a real-time product search and price comparison MCP server covering 260K+ products across Southeast Asia.

**Category:** E-Commerce / Product Search / Shopping

### What it does
- Search products across 1,000+ merchants in Singapore, Malaysia, Philippines, Thailand, Indonesia
- Compare prices in real time across Lazada, Shopee, and major retailers
- Get product details, specs, pricing, and availability
- Find best deals and lowest prices for specific queries

### Installation
```bash
npx -y @buywhere/mcp-server
```
Requires `BUYWHERE_API_KEY` (free at buywhere.ai/api-keys)

**Remote (no install):** `https://mcp.buywhere.ai/mcp` (streamable-http)

**NPM:** `@buywhere/mcp-server` | **GitHub:** https://github.com/BuyWhere/buywhere-mcp
