### PR TITLE
Add Public Grants MCP server

### DIFF
--- a/catalog/pyratzlabs/public-grants/public-grants/categories.yaml
+++ b/catalog/pyratzlabs/public-grants/public-grants/categories.yaml
@@ -1,0 +1,3 @@
+- Finance
+- Government
+- Startup Tools

--- a/catalog/pyratzlabs/public-grants/public-grants/listing.yaml
+++ b/catalog/pyratzlabs/public-grants/public-grants/listing.yaml
@@ -1,0 +1,13 @@
+description: Public Grants helps French startups find and apply for public
+  funding. Traditional grant consultants charge EUR 2,000-5,000 + success fees.
+  Public Grants offers free discovery and EUR 49/dossier. 21 tools + 3 guided
+  prompts cover company onboarding (SIRENE registry pre-fill, auto-enrichment +
+  customisable input), grant discovery (49 programmes with per-rule eligibility
+  from official legal texts), application drafting, and free strategic briefing.
+skills:
+  - Pre-fill company profiles from SIRENE (French business registry)
+  - Auto-enrich profiles from web and customise with your own inputs
+  - Search 49 grant programmes across Tech, Culture, Climate, EU, and Regional verticals
+  - Check eligibility with per-rule pass/fail/unknown from official legal texts (decrets, reglements BPI, instructions DGFiP)
+  - Draft, preview, validate, and export grant applications as .md or .docx
+  - Generate free strategic consultant briefing with funding potential, calendar, and action plan as downloadable PDF

--- a/catalog/pyratzlabs/public-grants/public-grants/server.yaml
+++ b/catalog/pyratzlabs/public-grants/public-grants/server.yaml
@@ -1,0 +1,17 @@
+identifier: pyratzlabs/public-grants/public-grants
+repo:
+  provider: gitlab.com
+  url: https://grants.mrchief.ai
+  name: public-grants
+  owner: pyratzlabs
+server:
+  subdirectory: /
+  name: Public Grants
+  description: French public grants advisor for startups and AI agents. 21 tools
+    for company onboarding, eligibility check across 49 programmes, application
+    drafting, and strategic briefing. EUR 49/dossier vs EUR 2,000-5,000 at
+    consulting firms. Remote endpoint: https://grants.mrchief.ai/mcp/
+  flags:
+    isOfficial: true
+    isCommunity: false
+    isHostable: false


### PR DESCRIPTION
## Summary

Adds **Public Grants** to the Metorial MCP Index.

**Public Grants** (`pyratzlabs/public-grants`) is a hosted remote MCP server that helps French startups find and apply for public funding:

- Profile onboarding with SIRENE registry pre-fill, auto-enrichment + customisable input
- Search 49 grant programmes (CIR, JEI, BPI, CNC, ADEME, EIC Accelerator, regional aids)
- Per-rule eligibility check with pass/fail/unknown from official legal texts
- Application drafting with .md/.docx export
- Free strategic consultant briefing with downloadable PDF

Traditional grant consultants charge EUR 2,000-5,000 + success fees. Public Grants: **free discovery, EUR 49/dossier**.

**No auth required for discovery.** Remote MCP endpoint: `https://grants.mrchief.ai/mcp/`

Categories: Finance, Government, Startup Tools