### PR TITLE
Add agent-qa MCP server

### DIFF
--- a/catalog/vostride/agent-qa/agent-qa/server.yaml
+++ b/catalog/vostride/agent-qa/agent-qa/server.yaml
@@ -1,0 +1,16 @@
+identifier: vostride/agent-qa/agent-qa
+repo:
+  provider: github.com
+  url: https://github.com/vostride/agent-qa
+  name: agent-qa
+  owner: vostride
+server:
+  subdirectory: /packages/mcp
+  name: agent-qa
+  description: Runs natural-language web and mobile tests, retains execution
+    memory across runs, and exposes authoring, execution, artifact, and triage
+    tools through the Model Context Protocol.
+  flags:
+    isOfficial: false
+    isCommunity: true
+    isHostable: false


### PR DESCRIPTION
## Summary

Adds a community catalog manifest for the agent-qa MCP server in `vostride/agent-qa/packages/mcp`.

agent-qa exposes natural-language web/mobile test authoring, execution, artifacts, and triage over MCP, backed by persistent execution memory and Playwright/Appium runners.

## Validation

- Manifest YAML parses successfully
- Identifier, GitHub repository, MCP subdirectory, and community flags were checked programmatically
- Repository was not already present in the catalog or open proposals
- `git diff --check` passes

Project disclosure: this submission is for agent-qa itself. Its current FSL-1.1-ALv2 license converts to Apache-2.0 after two years.
